### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Auto Dump And Compile autoload....
 `Well, after the download is finished, you will see these instructions, please follow them carefully`
 
 
-to Install (wkhtmltopdf) please visit this link urgently (https://github.com/barryvdh/laravel-snappy) to explort PDF Files with YajraDatatable
+to Install (wkhtmltopdf) please visit this link urgently (https://github.com/barryvdh/laravel-snappy) to export PDF Files with YajraDatatable
 
 To Install (wkhtmltopdf) with brew on macosx brew install wkhtmltopdf
 

--- a/it/Commands/Generate.php
+++ b/it/Commands/Generate.php
@@ -297,7 +297,7 @@ class Generate extends Command {
 		shell_exec('php artisan config:clear');
 		$this->progress(100);
 
-		$this->warn("to Install (wkhtmltopdf) please visit this link urgently (https://github.com/barryvdh/laravel-snappy) to explort PDF Files with YajraDatatable");
+		$this->warn("to Install (wkhtmltopdf) please visit this link urgently (https://github.com/barryvdh/laravel-snappy) to export PDF Files with YajraDatatable");
 
 		$this->warn("To Install (wkhtmltopdf) with brew on macosx brew install wkhtmltopdf");
 


### PR DESCRIPTION
Change 

`explort` to `export`

in `README` and `Generate.php` files 